### PR TITLE
fix for release date and folder name when install from HACS

### DIFF
--- a/custom_components/couchpotato/manifest.json
+++ b/custom_components/couchpotato/manifest.json
@@ -1,6 +1,6 @@
 {
-  "domain": "CoachPotato",
-  "name": "CoachPotato",
+  "domain": "couchpotato",
+  "name": "couchpotato",
   "documentation": "",
   "requirements": [],
   "dependencies": [],

--- a/custom_components/couchpotato/sensor.py
+++ b/custom_components/couchpotato/sensor.py
@@ -80,7 +80,10 @@ class CouchPotatoSensor(Entity):
 
         for movie in ifs_movies['movies']:
             card_items = {}
-            card_items['airdate'] = movie['info']['released']
+            if "released" in movie['info']:
+              card_items['airdate'] = movie['info']['released']
+            else:
+              card_items['airdate'] = datetime.fromtimestamp(movie['info']['release_date']['expires']).strftime("%Y-%m-%d")
             card_items['episode'] = ""
             card_items['release'] = "$day, $date $time"
             if "original_title" in movie['info']:


### PR DESCRIPTION
1. HACS uses the manifest to create the folder for the component. So fixing the name there should make it easy to install via HACS.
2. The other fix is for the `card_items['airdate'] = movie['info']['released']` - movies that will release in the future don't have released property in info. in that case movie['info']['release_date']['expires'] will be used.